### PR TITLE
Us5

### DIFF
--- a/app/controllers/merchant_discounts_controller.rb
+++ b/app/controllers/merchant_discounts_controller.rb
@@ -19,6 +19,16 @@ class MerchantDiscountsController < ApplicationController
     redirect_to "/merchants/#{merchant.id}/discounts"
   end
 
+  def edit
+    @discount = Discount.find(params[:id])
+  end
+
+  def update
+    discount = Discount.find(params[:id])
+    discount.update(discount_params)
+    redirect_to "/merchants/#{params[:merchant_id]}/discounts/#{discount.id}"
+  end
+
   def destroy
     discount = Discount.find(params[:id])
     discount.destroy
@@ -28,6 +38,6 @@ class MerchantDiscountsController < ApplicationController
   private
 
   def discount_params
-    params.required(:discount).permit(:discount, :quantity)
+    params.permit(:discount, :quantity)
   end
 end

--- a/app/views/merchant_discounts/edit.html.erb
+++ b/app/views/merchant_discounts/edit.html.erb
@@ -1,0 +1,9 @@
+<h1>Edit Discount</h1>
+
+<%= form_with url: "/merchants/#{@discount.merchant.id}/discounts/#{@discount.id}/edit" do |form| %>
+<%= form.label :quantity, "Quantity Threshold" %>
+<%= form.number_field :quantity, in: 1..2000, step: 1, value: @discount.quantity %><br>
+<%= form.label :discount, "Percent Discounted" %>
+<%= form.number_field :discount, in: 1..99, step: 1, value: @discount.discount %><br>
+<%= form.submit "Update Discount" %>
+<% end %>

--- a/app/views/merchant_discounts/show.html.erb
+++ b/app/views/merchant_discounts/show.html.erb
@@ -1,5 +1,9 @@
 <h1>Bulk Discount <%= @discount.id %></h1>
 <div class="discount-attributes">
-  <h3> Discount :  <%= @discount.discount %> %</h3>
+  <h3> Discount:  <%= @discount.discount %> %</h3>
   <h3> Quantity Threshold:  <%= @discount.quantity %> </h3>
+</div>
+
+<div class="edit-discount">
+  <h3> <%= link_to "Edit Discount", "/merchants/#{@discount.merchant.id}/discounts/#{@discount.id}/edit", method: :get%> </h3>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
   # get "merchants/:merchant_id/discounts", to: "merchant_discounts#index"
   # get "merchants/:merchant_id/discounts/new", to: "merchant_discounts#new"
   # post "merchants/:merchant_id/discounts/new", to: "merchant_discounts#create"
+  post "merchants/:merchant_id/discounts/:id/edit", to: "merchant_discounts#update"
 
   namespace :admin do
     resources :merchants, only: [:index, :show, :new, :create, :edit, :update]

--- a/spec/features/merchants/discounts/edit_spec.rb
+++ b/spec/features/merchants/discounts/edit_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+RSpec.describe "merchant discounts edit" do
+  it "populates form with existing attributes" do
+    merchant1 = Merchant.create!(name: "Edit Page Sparkle")
+    discount1 = merchant1.discounts.create!(discount: 20, quantity: 10)
+    # discount2 = merchant1.discounts.create!(discount: 50, quantity: 15)
+
+    visit "/merchants/#{merchant1.id}/discounts/#{discount1.id}/edit"
+
+    expect(page).to have_field(:quantity, with: 10)
+    expect(page).to have_field(:discount, with: 20.0)
+
+    fill_in(:quantity, with: 15)
+    fill_in(:discount, with: 50)
+
+    click_button("Update Discount")
+
+    expect(current_path).to eq("/merchants/#{merchant1.id}/discounts/#{discount1.id}")
+
+    expect(page).to have_content("Discount: 50.0 %")
+    expect(page).to have_content("Quantity Threshold: 15")
+    expect(page).not_to have_content("Discount: 10")
+    expect(page).not_to have_content("Quantity: 5")
+
+    expect(Discount.find(discount1.id).quantity).to eq(15)
+    expect(Discount.find(discount1.id).discount).to eq(50)
+  end
+end

--- a/spec/features/merchants/discounts/show_spec.rb
+++ b/spec/features/merchants/discounts/show_spec.rb
@@ -17,8 +17,22 @@ RSpec.describe "the merchant bulk discounts show" do
     visit "/merchants/#{merchant1.id}/discounts/#{discount1.id}"
 
     within ".discount-attributes" do
-      expect(page).to have_content("Discount : #{discount1.discount} %")
+      expect(page).to have_content("Discount: #{discount1.discount} %")
       expect(page).to have_content("Quantity Threshold: #{discount1.quantity}")
     end
+  end
+
+  it "has a link to edit the discount that routes to the edit page" do
+    merchant1 = Merchant.create!(name: "Show Page Sparkle")
+    discount1 = merchant1.discounts.create!(discount: 20, quantity: 10)
+
+    visit "/merchants/#{merchant1.id}/discounts/#{discount1.id}"
+
+    within ".edit-discount" do
+      expect(page).to have_link("Edit Discount")
+      click_link "Edit Discount"
+    end
+
+    expect(current_path).to eq("/merchants/#{merchant1.id}/discounts/#{discount1.id}/edit")
   end
 end


### PR DESCRIPTION
Merchant Bulk Discount Edit

As a merchant
When I visit my bulk discount show page
Then I see a link to edit the bulk discount
When I click this link
Then I am taken to a new page with a form to edit the discount
And I see that the discounts current attributes are pre-poluated in the form
When I change any/all of the information and click submit
Then I am redirected to the bulk discount's show page
And I see that the discount's attributes have been updated