### PR TITLE
Holiday API consumtion test/feat holiday poros services and view

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,7 @@ class ApplicationController < ActionController::Base
   # def repo_info
   #   @github_info = GithubSearch.new.output
   # end
+  def next_3_holidays
+    @holidays = HolidayFacade.find_holidays
+  end
 end

--- a/app/controllers/merchant_discounts_controller.rb
+++ b/app/controllers/merchant_discounts_controller.rb
@@ -1,6 +1,7 @@
 class MerchantDiscountsController < ApplicationController
   def index
     @merchant = Merchant.find(params[:merchant_id])
+    @facade = HolidayFacade.new
   end
 
   def show

--- a/app/facades/holiday_facade.rb
+++ b/app/facades/holiday_facade.rb
@@ -1,0 +1,18 @@
+require_relative "../services/holiday_service"
+require_relative "../poros/holiday"
+
+class HolidayFacade
+  def holidays
+    holiday_data.map do |data|
+      Holiday.new(data)
+    end
+  end
+
+  def service
+    @_service ||= HolidayService.new
+  end
+
+  def holiday_data
+    @_holiday_data ||= service.get_holidays
+  end
+end

--- a/app/poros/holiday.rb
+++ b/app/poros/holiday.rb
@@ -1,0 +1,13 @@
+class Holiday
+  attr_reader :name, :date
+
+  def initialize(data)
+    @name = data[:name]
+    @date = data[:date]
+    @date = DateTime.strptime(data[:date], "%Y-%m-%d")
+  end
+
+  def format_date
+    @date.strftime("%B %d, %Y")
+  end
+end

--- a/app/services/holiday_service.rb
+++ b/app/services/holiday_service.rb
@@ -1,0 +1,13 @@
+require "json"
+require "httparty"
+
+class HolidayService
+  def get_holidays
+    get_url("https://date.nager.at/api/v3/NextPublicHolidays/US")
+  end
+
+  def get_url(url)
+    response = HTTParty.get(url)
+    json = JSON.parse(response.body, symbolize_names: true)
+  end
+end

--- a/app/views/merchant_discounts/index.html.erb
+++ b/app/views/merchant_discounts/index.html.erb
@@ -3,7 +3,7 @@
 <% @merchant.discounts.each_with_index do |discount, index| %>
 <div class="discount-<%= discount.id %>">
   <h3><%= link_to "Discount ID: #{discount.id}" , "/merchants/#{@merchant.id}/discounts/#{discount.id}"%></h3>
-  <p><%= index + 1 %>. <%="#{discount.discount}% discount applied to quanitiy of #{discount.quantity} items."%></p>
+  <p><%= index + 1 %>. <%=number_to_percentage(discount.discount*100, precision: 0)%><%=" discount applied to the quantity of #{discount.quantity} items."%></p>
   <p> <%= link_to "Delete Discount", "/merchants/#{@merchant.id}/discounts/#{discount.id}", method: :delete %> </p>
 </div>
 <% end %>
@@ -11,3 +11,9 @@
 <div class="create-discount">
   <h3> <%= link_to "Create New Discount", "/merchants/#{@merchant.id}/discounts/new" %> </h3>
 </div>
+
+  <h2> Upcoming Holidays </h2>
+  <%= @facade.holidays[0..2].each do |holiday| %>
+    <h3> <%= holiday.name %> </h3>
+    <p> <%= holiday.format_date %> </p>
+    <% end %>

--- a/spec/features/merchants/discounts/index_spec.rb
+++ b/spec/features/merchants/discounts/index_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe "merchant discounts index" do
 
     within ".discount-#{discount.id}" do
       expect(page).to have_link("Discount ID: #{discount.id}")
-      expect(page).to have_content("#{discount.discount}% discount applied to quanitiy of #{discount.quantity} items.")
+      expect(page).to have_content("25% discount applied to the quantity of #{discount.quantity} items.")
     end
     expect(page).to_not have_link("Discount ID: #{discount_3.id}")
-    expect(page).to_not have_content("#{discount_3.discount}% discount applied to quanitiy of #{discount_3.quantity} items.")
+    expect(page).to_not have_content("50% discount applied to the quantity of #{discount_3.quantity} items.")
 
     within ".discount-#{discount_2.id}" do
       expect(page).to have_link("Discount ID: #{discount_2.id}")
-      expect(page).to have_content("#{discount_2.discount}% discount applied to quanitiy of #{discount_2.quantity} items.")
+      expect(page).to have_content("75% discount applied to the quantity of #{discount_2.quantity} items.")
     end
 
     visit "/merchants/#{@merchant1.id}/discounts"
@@ -52,7 +52,7 @@ RSpec.describe "merchant discounts index" do
 
     within ".discount-#{discount.id}" do
       expect(page).to have_link("Discount ID: #{discount.id}")
-      expect(page).to have_content("#{discount.discount}% discount applied to quanitiy of #{discount.quantity} items.")
+      expect(page).to have_content("25% discount applied to the quantity of #{discount.quantity} items.")
       expect(page).to have_link("Delete Discount")
       click_link "Delete Discount"
     end
@@ -60,6 +60,16 @@ RSpec.describe "merchant discounts index" do
     expect(current_path).to eq("/merchants/#{@merchant1.id}/discounts")
 
     expect(page).to_not have_link("Discount ID: #{discount.id}")
-    expect(page).to_not have_content("#{discount.discount}% discount applied to quanitiy of #{discount.quantity} items.")
+    expect(page).to_not have_content("25% discount applied to the quantity of #{discount.quantity} items.")
+  end
+
+  it "shows the upcoming hoidays and dates" do
+    merchants = FactoryBot.create_list(:merchant, 2)
+
+    visit "/merchants/#{merchants[0].id}/discounts"
+
+    expect(page).to have_content("Memorial Day")
+    expect(page).to have_content("Juneteenth")
+    expect(page).to have_content("Independence Day")
   end
 end

--- a/spec/poros/holiday_spec.rb
+++ b/spec/poros/holiday_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Holiday do
+  describe "it has attributes" do
+    it "initialize" do
+      holiday = Holiday.new({name: "Christmas", date: "2022-12-25"})
+
+      expect(holiday.name).to eq("Christmas")
+      expect(holiday.date).to eq("2022-12-25")
+    end
+  end
+
+  describe ".instance methods" do
+    it "format_date" do
+      holiday = Holiday.new({name: "Christmas", date: "2022-12-25"})
+
+      expect(holiday.format_date).to eq("December 25, 2022")
+    end
+  end
+end


### PR DESCRIPTION
As a merchant
When I visit the discounts index page
I see a section with a header of "Upcoming Holidays"
In this section the name and date of the next 3 upcoming US holidays are listed.

Use the Next Public Holidays Endpoint in the [Nager.Date API](https://date.nager.at/swagger/index.html)
